### PR TITLE
Only have mixins as abstract if they shadow something and make mixin methods private

### DIFF
--- a/src/main/java/com/zorbatron/zbgt/mixin/PSSMixin.java
+++ b/src/main/java/com/zorbatron/zbgt/mixin/PSSMixin.java
@@ -17,12 +17,12 @@ import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityPowerSubstation;
 
 @Mixin(value = MetaTileEntityPowerSubstation.class, remap = false)
-public abstract class PSSMixin {
+public class PSSMixin {
 
     @Redirect(method = "createStructurePattern",
               at = @At(value = "INVOKE",
                        target = "Lgregtech/api/pattern/FactoryBlockPattern;setRepeatable(II)Lgregtech/api/pattern/FactoryBlockPattern;"))
-    public FactoryBlockPattern setRepeatable(FactoryBlockPattern instance, int minRepeat, int maxRepeat) {
+    private FactoryBlockPattern setRepeatable(FactoryBlockPattern instance, int minRepeat, int maxRepeat) {
         return instance.setRepeatable(minRepeat, ZBGTConfig.multiblockSettings.overridePSSHeight ?
                 ZBGTConfig.multiblockSettings.overriddenPSSHeight : maxRepeat);
     }

--- a/src/main/java/com/zorbatron/zbgt/mixin/WorldGenRegistryMixin.java
+++ b/src/main/java/com/zorbatron/zbgt/mixin/WorldGenRegistryMixin.java
@@ -18,7 +18,7 @@ import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
 
 @Mixin(value = WorldGenRegistry.class, remap = false)
-public abstract class WorldGenRegistryMixin {
+public class WorldGenRegistryMixin {
 
     /**
      * @author Zorbatron


### PR DESCRIPTION
Recommended by CEu devs :heart: 